### PR TITLE
Handle IOException and SocketException

### DIFF
--- a/src/Apache.IoTDB/SessionPool.cs
+++ b/src/Apache.IoTDB/SessionPool.cs
@@ -227,7 +227,7 @@ namespace Apache.IoTDB
 
             if (_clients.ClientQueue.Count != _poolSize)
             {
-                throw new TException(string.Format("Error occurs when opening session pool. Client pool size is not equal to the expected size. Client pool size: {0}, expected size: {1}", _clients.ClientQueue.Count, _poolSize), null);
+                throw new TException(string.Format("Error occurs when opening session pool. Client pool size is not equal to the expected size. Client pool size: {0}, expected size: {1}, Please check the server status", _clients.ClientQueue.Count, _poolSize), null);
             }
             _isClose = false;
         }

--- a/src/Apache.IoTDB/SessionPool.cs
+++ b/src/Apache.IoTDB/SessionPool.cs
@@ -113,20 +113,6 @@ namespace Apache.IoTDB
         public async Task<TResult> ExecuteClientOperationAsync<TResult>(AsyncOperation<TResult> operation, string errMsg, bool retryOnFailure = true)
         {
             Client client = _clients.Take();
-            Func<Client, Task<TResult>> executeWithReconnect = async (currentClient) =>
-            {
-                try
-                {
-                    currentClient = await Reconnect(currentClient);
-                    var response = await operation(currentClient);
-                    return response;
-                }
-                catch (TException retryEx)
-                {
-                    throw new TException(errMsg, retryEx);
-                }
-            };
-
             try
             {
                 var resp = await operation(client);
@@ -136,7 +122,13 @@ namespace Apache.IoTDB
             {
                 if (retryOnFailure)
                 {
-                    return await executeWithReconnect(client);
+                    try{
+                        client = await Reconnect(client);
+                        return await operation(client);
+                    } catch (TException retryEx)
+                    {
+                        throw new TException(errMsg, retryEx);
+                    }
                 }
                 else
                 {
@@ -147,7 +139,13 @@ namespace Apache.IoTDB
             {
                 if (retryOnFailure)
                 {
-                    return await executeWithReconnect(client);
+                    try{
+                        client = await Reconnect(client);
+                        return await operation(client);
+                    } catch (TException retryEx)
+                    {
+                        throw new TException(errMsg, retryEx);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This PR fixes #13

1. The `SocketException` is caused by the unhandled Exception in `Open` method, stemming from the initialization process of `TCPClient`.
2. The `IOException` occurred due to a missing transport closure in the `Reconnect` method when only one single endpoint is available.

With these changes, a unified exception type is now returned when a query statement execution fails.