### PR TITLE
fix: incorrect column order in results returned by SELECT statements

### DIFF
--- a/samples/Apache.IoTDB.Samples/SessionPoolTest.Record.cs
+++ b/samples/Apache.IoTDB.Samples/SessionPoolTest.Record.cs
@@ -295,6 +295,22 @@ namespace Apache.IoTDB.Samples
             Console.WriteLine(res_count + " " + fetch_size * processed_size);
             System.Diagnostics.Debug.Assert(res_count == record_count);
             System.Diagnostics.Debug.Assert(status == 0);
+
+            string sql = string.Format("select {0}, {1}, {2} from ", test_measurements[3], test_measurements[1], test_measurements[2]) + string.Format("{0}.{1}", test_group_name, test_device);
+            res = await session_pool.ExecuteQueryStatementAsync(sql);
+            res.ShowTableNames();
+            RowRecord row = null;
+            while (res.HasNext())
+            {
+                row = res.Next();
+                break;
+            }
+            
+            Console.WriteLine($"{test_group_name}.{test_device}.{row.Measurements[0]}  {test_measurements[3]}");
+            System.Diagnostics.Debug.Assert($"{test_group_name}.{test_device}.{test_measurements[3]}" == row.Measurements[0]);
+            System.Diagnostics.Debug.Assert($"{test_group_name}.{test_device}.{test_measurements[1]}" == row.Measurements[1]);
+            System.Diagnostics.Debug.Assert($"{test_group_name}.{test_device}.{test_measurements[2]}" == row.Measurements[2]);
+            
             status = await session_pool.DeleteStorageGroupAsync(test_group_name);
             System.Diagnostics.Debug.Assert(status == 0);
             await session_pool.Close();

--- a/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
+++ b/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
@@ -63,6 +63,7 @@ namespace Apache.IoTDB.DataStructure
             _currentBitmap = new byte[_columnSize];
             _columnNames = new List<string>();
             _timeBuffer = new ByteBuffer(_queryDataset.Time);
+            // column name -> column location
             _columnNameIndexMap = new Dictionary<string, int>();
             _columnTypeLst = new List<string>();
             _duplicateLocation = new Dictionary<int, int>();
@@ -72,43 +73,31 @@ namespace Apache.IoTDB.DataStructure
             _hasCatchedResult = false;
             _rowIndex = 0;
             RowCount = _queryDataset.Time.Length / sizeof(long);
-            if (resp.ColumnNameIndexMap != null)
-            {
-                for (var index = 0; index < resp.Columns.Count; index++)
-                {
-                    _columnNames.Add("");
-                    _columnTypeLst.Add("");
-                }
 
-                for (var index = 0; index < resp.Columns.Count; index++)
-                {
-                    var name = resp.Columns[index];
-                    _columnNames[resp.ColumnNameIndexMap[name]] = name;
-                    _columnTypeLst[resp.ColumnNameIndexMap[name]] = resp.DataTypeList[index];
+            _columnNames = resp.Columns;
+            _columnTypeLst = resp.DataTypeList;
+
+            int deduplicateIdx = 0;
+            Dictionary<string, int> columnToFirstIndexMap = [];
+            for(var i = 0; i < _columnSize; i++){
+                var columnName = _columnNames[i];
+                if(_columnNameIndexMap.ContainsKey(columnName)){
+                    _duplicateLocation[i] = columnToFirstIndexMap[columnName];
+                } else {
+                    columnToFirstIndexMap[columnName] = i;
+                    if(resp.ColumnNameIndexMap != null) {
+                        int valueIndex = resp.ColumnNameIndexMap[columnName];
+                        _columnNameIndexMap[columnName] = valueIndex;
+                        _valueBufferLst.Add(new ByteBuffer(_queryDataset.ValueList[valueIndex]));
+                        _bitmapBufferLst.Add(new ByteBuffer(_queryDataset.BitmapList[valueIndex]));
+                    } else {
+                        _columnNameIndexMap[columnName] = deduplicateIdx;
+                        _valueBufferLst.Add(new ByteBuffer(_queryDataset.ValueList[deduplicateIdx]));
+                        _bitmapBufferLst.Add(new ByteBuffer(_queryDataset.BitmapList[deduplicateIdx]));
+                    }
+                    deduplicateIdx++;
                 }
             }
-            else
-            {
-                _columnNames = resp.Columns;
-                _columnTypeLst = resp.DataTypeList;
-            }
-
-            for (int index = 0; index < _columnNames.Count; index++)
-            {
-                var columnName = _columnNames[index];
-                if (_columnNameIndexMap.ContainsKey(columnName))
-                {
-                    _duplicateLocation[index] = _columnNameIndexMap[columnName];
-                }
-                else
-                {
-                    _columnNameIndexMap[columnName] = index;
-                }
-
-                _valueBufferLst.Add(new ByteBuffer(_queryDataset.ValueList[index]));
-                _bitmapBufferLst.Add(new ByteBuffer(_queryDataset.BitmapList[index]));
-            }
-
         }
         public List<string> ColumnNames => _columnNames;
 
@@ -282,8 +271,10 @@ namespace Apache.IoTDB.DataStructure
                     _bitmapBufferLst = new List<ByteBuffer>();
                     for (int index = 0; index < _queryDataset.ValueList.Count; index++)
                     {
-                        _valueBufferLst.Add(new ByteBuffer(_queryDataset.ValueList[index]));
-                        _bitmapBufferLst.Add(new ByteBuffer(_queryDataset.BitmapList[index]));
+                        string columnName = _columnNames[index];
+                        int valueIndex = _columnNameIndexMap[columnName];
+                        _valueBufferLst.Add(new ByteBuffer(_queryDataset.ValueList[valueIndex]));
+                        _bitmapBufferLst.Add(new ByteBuffer(_queryDataset.BitmapList[valueIndex]));
                     }
 
                     // reset row index

--- a/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
+++ b/src/Apache.IoTDB/DataStructure/SessionDataSet.cs
@@ -78,7 +78,7 @@ namespace Apache.IoTDB.DataStructure
             _columnTypeLst = resp.DataTypeList;
 
             int deduplicateIdx = 0;
-            Dictionary<string, int> columnToFirstIndexMap = [];
+            Dictionary<string, int> columnToFirstIndexMap = new Dictionary<string, int>();
             for(var i = 0; i < _columnSize; i++){
                 var columnName = _columnNames[i];
                 if(_columnNameIndexMap.ContainsKey(columnName)){


### PR DESCRIPTION
This PR addresses an issue where the column names in the result set returned by a SELECT statement did not follow the order specified in the query. Instead, they were returned in an unexpected or incorrect sequence.

Changes:
- Change initlization logic for `SessionDataSet` to maintain correct column order.
- Added corresponding tests.

#21 