### PR TITLE
Fix DNS resolution failure on Linux when host is an IP address (#50)

### DIFF
--- a/src/Apache.IoTDB/SessionPool.cs
+++ b/src/Apache.IoTDB/SessionPool.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -450,9 +451,19 @@ namespace Apache.IoTDB
         private async Task<Client> CreateAndOpen(string host, int port, bool enableRpcCompression, int timeout, bool useSsl, string cert, string sqlDialect, string database, CancellationToken cancellationToken = default)
         {
 
-            TTransport socket = useSsl ?
-                new TTlsSocketTransport(host, port, null, timeout, new X509Certificate2(File.ReadAllBytes(cert))) :
-                new TSocketTransport(host, port, null, timeout);
+            TTransport socket;
+            if (IPAddress.TryParse(host, out var ipAddress))
+            {
+                socket = useSsl
+                    ? new TTlsSocketTransport(ipAddress, port, null, timeout, new X509Certificate2(File.ReadAllBytes(cert)))
+                    : new TSocketTransport(ipAddress, port, null, timeout);
+            }
+            else
+            {
+                socket = useSsl
+                    ? new TTlsSocketTransport(host, port, null, timeout, new X509Certificate2(File.ReadAllBytes(cert)))
+                    : new TSocketTransport(host, port, null, timeout);
+            }
 
             var transport = new TFramedTransport(socket);
 


### PR DESCRIPTION
## Summary

Fixes #50.

On Linux, `SessionPool.CreateAndOpen` fails with `Thrift.Transport.TTransportException: Name or service not known` even when a valid IP literal is supplied. Root cause: the 4-arg `TSocketTransport(string host, int port, TConfiguration, int timeout)` constructor unconditionally calls `Dns.GetHostEntry(host)`. On Linux, `GetHostEntry` with an IP string performs reverse lookup first, then re-resolves the returned hostname forward — if either step fails, a `SocketException` is thrown. Windows is more permissive and hides the bug.

## Fix

Pre-parse the host with `IPAddress.TryParse`:
- **IP literal** → use `TSocketTransport(IPAddress, …)` / `TTlsSocketTransport(IPAddress, …, cert)` overload, which skips DNS entirely.
- **Hostname** → keep the existing string-based path (DNS still resolves normally).

File changed: `src/Apache.IoTDB/SessionPool.cs` (+14 / -3).

## Test plan
- [x] `dotnet build -c Release` passes on all target frameworks (`net5.0`, `net6.0`, `netstandard2.1`, `netstandard2.0`, `net461`) — 0 errors.
- [ ] Manual smoke: connect with `SessionPool(host="<IPv4>", port=6667, …)` on a Linux host whose `/etc/hosts` does **not** map the IP; expect successful connection.
- [ ] Regression: connect with a hostname (e.g. `localhost`) — expect unchanged behavior.