### PR TITLE
Upgrade ApacheThrift to 0.22.0 and fix socket transport creation

### DIFF
--- a/samples/Apache.IoTDB.Samples/Dockerfile
+++ b/samples/Apache.IoTDB.Samples/Dockerfile
@@ -17,7 +17,7 @@
 
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/runtime:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build

--- a/src/Apache.IoTDB/Apache.IoTDB.csproj
+++ b/src/Apache.IoTDB/Apache.IoTDB.csproj
@@ -17,14 +17,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ApacheThrift" Version="0.14.1" />
+        <PackageReference Include="ApacheThrift" Version="0.22.0" />
     </ItemGroup>
-    <ItemGroup
-        Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'">
+    <ItemGroup Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="IndexRange" Version="1.0.2" />
     </ItemGroup>
     <ItemGroup>
-        <None Include="../../README.md" Pack="true" PackagePath="\"/>
+        <None Include="../../README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/src/Apache.IoTDB/SessionPool.cs
+++ b/src/Apache.IoTDB/SessionPool.cs
@@ -21,6 +21,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -449,10 +450,18 @@ namespace Apache.IoTDB
 
         private async Task<Client> CreateAndOpen(string host, int port, bool enableRpcCompression, int timeout, bool useSsl, string cert, string sqlDialect, string database, CancellationToken cancellationToken = default)
         {
+            TTransport socket;
 
-            TTransport socket = useSsl ?
-                new TTlsSocketTransport(host, port, null, timeout, new X509Certificate2(File.ReadAllBytes(cert))) :
-                new TSocketTransport(host, port, null, timeout);
+            if (useSsl)
+            {
+                socket = IPAddress.TryParse(host, out var ipAddress)
+                    ? new TTlsSocketTransport(ipAddress, port, null, cert)
+                    : new TTlsSocketTransport(host, port, null, timeout, new X509Certificate2(cert));
+            }
+            else
+            {
+                socket = new TSocketTransport(host, port, false, null, timeout);
+            }
 
             var transport = new TFramedTransport(socket);
 


### PR DESCRIPTION
## Summary
- Upgrade `ApacheThrift` from `0.14.1` to `0.22.0`
- Update session pool transport creation to use the newer Thrift constructors
- Keep SSL and non-SSL paths compatible with IP literals and hostnames

## Testing
- Build validated locally for the `Apache.IoTDB` project
- No unit tests were added for this change