### PR TITLE
[codex] Upgrade ApacheThrift to 0.23.0

### DIFF
--- a/src/Apache.IoTDB/Apache.IoTDB.csproj
+++ b/src/Apache.IoTDB/Apache.IoTDB.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ApacheThrift" Version="0.22.0" />
+        <PackageReference Include="ApacheThrift" Version="0.23.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="IndexRange" Version="1.0.2" />


### PR DESCRIPTION
## Summary

- Upgrade the ApacheThrift package reference from 0.22.0 to 0.23.0, the latest NuGet release.

## Validation

- `dotnet restore src/Apache.IoTDB/Apache.IoTDB.csproj`
- `dotnet build src/Apache.IoTDB/Apache.IoTDB.csproj --no-restore` passed with dependency target-framework warnings.
- `dotnet test tests/Apache.IoTDB.Tests/Apache.IoTDB.Tests.csproj` built successfully, but test execution aborted locally because only arm64 .NET 8 is installed and the test runner looked for an x64 dotnet host.
- `dotnet restore Apache.IoTDB.sln` could not run locally because the samples project targets net9.0 while this machine has .NET SDK 8.0.122.