### PR TITLE
Add SessionPool.CheckHealthAsync connectivity probe 新增 SessionPool.CheckHealthAsync 连通性探针

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -44,7 +44,8 @@ var tablet =
 | -------------- | ------------------------- | ------------------------ | ----------------------------- |
 | Open           | bool                      | open session             | session_pool.Open(false)      |
 | Close          | null                      | close session            | session_pool.Close()          |
-| IsOpen         | null                      | check if the pool was opened and not yet closed by the caller. It is a lifecycle flag, **not** a connectivity probe: it stays `true` after the server goes down, because the client keeps no heartbeat and reconnects on demand instead. | session_pool.IsOpen()         |
+| IsOpen         | null                      | check whether the pool was opened and not yet closed by the caller. It is a lifecycle flag, **not** a connectivity probe: it stays `true` after the server goes down, because the client keeps no heartbeat and reconnects on demand instead. For connectivity use `CheckHealthAsync` | session_pool.IsOpen()         |
+| CheckHealthAsync | CancellationToken=default | probe server connectivity on an idle pooled connection; returns a `SessionPoolHealth` snapshot | await session_pool.CheckHealthAsync() |
 | OpenDebugMode  | LoggingConfiguration=null | open debug mode          | session_pool.OpenDebugMode()  |
 | CloseDebugMode | null                      | close debug mode         | session_pool.CloseDebugMode() |
 | SetTimeZone    | string                    | set time zone            | session_pool.GetTimeZone()    |

--- a/docs/SessionPool_Exception_Handling.md
+++ b/docs/SessionPool_Exception_Handling.md
@@ -54,24 +54,62 @@ catch (SessionPoolDepletedException ex)
 }
 ```
 
-## `IsOpen()` is a lifecycle flag, not a health check
+## Checking connectivity: `CheckHealthAsync` vs `IsOpen`
 
-`SessionPool.IsOpen()` reports whether **you** have opened the pool and not yet closed it. It is not a
-connectivity probe:
+`SessionPool.IsOpen()` reports whether **you** have opened the pool and not yet closed it. It is a
+lifecycle flag, not a connectivity probe:
 
 - It becomes `true` after a successful `Open()` and only returns to `false` when you call `Close()`.
 - The client runs no heartbeat, so a server that goes down does **not** flip it back to `false`.
   Reconnection happens lazily, on the next operation.
 
-This means the following common guard never re-opens the pool, because the flag stays `true` forever:
+This makes the following common guard a trap - it short-circuits forever, so the pool is never rebuilt:
 
 ```csharp
-// Anti-pattern: this short-circuits even while every connection is dead
+// Anti-pattern: IsOpen() stays true even while every connection is dead
 if (_pool != null && _pool.IsOpen()) return;
 ```
 
-To reason about actual availability, use the health metrics below, or simply let an operation throw
-`SessionPoolDepletedException` and handle it.
+Use `CheckHealthAsync` when you need to know whether the server is actually reachable. It issues one
+lightweight request on an idle pooled connection and returns a `SessionPoolHealth` snapshot:
+
+```csharp
+var health = await sessionPool.CheckHealthAsync();
+
+if (!health.IsHealthy)
+{
+    Console.WriteLine(health);            // e.g. "Unhealthy: The server did not answer the probe: ..."
+    Console.WriteLine(health.Status);     // NotOpen | Healthy | Degraded | Unhealthy
+    Console.WriteLine(health.Error);      // the underlying exception, when Status is Unhealthy
+}
+```
+
+### Status values
+
+| Status      | Meaning                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------- |
+| `NotOpen`   | The pool has not been opened yet, or has already been closed. No network call is attempted.  |
+| `Healthy`   | The server answered the probe.                                                              |
+| `Degraded`  | The pool is open but no connection was idle to probe with. Says nothing about the server.    |
+| `Unhealthy` | A connection was available but the server did not answer. See `Error` for the cause.         |
+
+### Behaviour worth knowing
+
+- **The probe never blocks.** If every client is busy, it returns `Degraded` immediately instead of
+  queueing behind ordinary work, so a health endpoint cannot be starved by application load. It is also
+  unaffected by the pool wait timeout described below.
+- **The borrowed connection is always returned** to the pool, and a failed probe does not close it. The
+  regular reconnect-on-use path still applies to the next operation.
+- **`Degraded` is not a server verdict.** Under high concurrency it simply means the pool was saturated at
+  that instant. Treat a persistent `Degraded` as a sizing signal, not an outage.
+- **Bound the probe yourself if you need to.** Pass a cancellation token:
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+var health = await sessionPool.CheckHealthAsync(cts.Token);
+```
+
+`TableSessionPool` exposes the same `CheckHealthAsync` method with identical semantics.
 
 ## Pool Wait Timeout
 
@@ -94,7 +132,9 @@ var sessionPool = new SessionPool.Builder()
 
 When the wait budget is exhausted, the operation throws `SessionPoolDepletedException` with the reason
 `Connection pool is empty and wait time out(...ms)`. Raise `SetPoolWaitTimeoutInMs` if your workload
-legitimately queues behind long operations; lower it if you would rather fail fast and retry.
+legitimately queues behind long operations; lower it if you would rather fail fast and retry. The budget is
+a single deadline for the whole call: waiters woken by a returned connection that they lose the race for do
+not restart it.
 
 > **Note:** before this setting existed, the wait budget was derived from the connection timeout and then
 > misinterpreted as seconds, which turned the 500 ms default into a ~41 minute block. If you are upgrading
@@ -333,6 +373,8 @@ var sessionPool = new SessionPool.Builder()
 
 ### Health Check Implementation
 
+The simplest health check delegates to the built-in probe and only adds your own policy on top:
+
 ```csharp
 public class SessionPoolHealthCheck
 {
@@ -343,26 +385,27 @@ public class SessionPoolHealthCheck
         _pool = pool;
     }
 
-    public HealthStatus CheckHealth()
+    public async Task<HealthStatus> CheckHealthAsync()
     {
-        var availableRatio = (double)_pool.AvailableClients / _pool.TotalPoolSize;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        var health = await _pool.CheckHealthAsync(cts.Token);
 
-        if (_pool.FailedReconnections > 10)
+        if (health.Status == SessionPoolHealthStatus.Unhealthy)
         {
             return new HealthStatus
             {
                 Status = "Critical",
-                Message = $"High reconnection failures: {_pool.FailedReconnections}",
+                Message = health.Message,
                 Recommendation = "Check IoTDB server availability"
             };
         }
 
-        if (availableRatio < 0.25)
+        if (health.Status == SessionPoolHealthStatus.Degraded)
         {
             return new HealthStatus
             {
                 Status = "Warning",
-                Message = $"Low available clients: {_pool.AvailableClients}/{_pool.TotalPoolSize}",
+                Message = $"No idle connection to probe ({health.AvailableClients}/{health.TotalPoolSize} available)",
                 Recommendation = "Consider increasing pool size"
             };
         }
@@ -370,7 +413,7 @@ public class SessionPoolHealthCheck
         return new HealthStatus
         {
             Status = "Healthy",
-            Message = $"Pool healthy: {_pool.AvailableClients}/{_pool.TotalPoolSize} available"
+            Message = health.Message
         };
     }
 }
@@ -382,6 +425,9 @@ public class HealthStatus
     public string Recommendation { get; set; }
 }
 ```
+
+If you would rather not issue a network call on every scrape, the metrics below can be sampled on their
+own - just remember they describe the pool, not the server.
 
 ### Metrics Collection for Monitoring Systems
 
@@ -559,7 +605,7 @@ public class ProductionSessionPoolManager
 The SessionPool exception handling and health monitoring features provide comprehensive tools for building robust IoTDB applications:
 
 - Use `SessionPoolDepletedException` to understand and react to pool issues
-- Treat `IsOpen()` as a lifecycle flag, never as a connectivity check
+- Use `CheckHealthAsync` for connectivity checks; `IsOpen()` is a lifecycle flag only
 - Tune `SetPoolWaitTimeoutInMs` separately from `SetConnectionTimeoutInMs`
 - Monitor `AvailableClients`, `TotalPoolSize`, and `FailedReconnections`; read `UnrealizedCapacity` as
   capacity not yet materialized rather than as an outage signal

--- a/src/Apache.IoTDB/ConcurrentClientQueue.cs
+++ b/src/Apache.IoTDB/ConcurrentClientQueue.cs
@@ -58,7 +58,6 @@ namespace Apache.IoTDB
         public void AddRef() => Interlocked.Increment(ref _ref);
         public int GetRef() => Volatile.Read(ref _ref);
         public void RemoveRef() => Interlocked.Decrement(ref _ref);
-
         /// <summary>
         /// The maximum time, in milliseconds, that <see cref="Take"/> waits for a client to be
         /// returned to the pool before throwing. Defaults to 10000 (10 seconds).
@@ -78,6 +77,12 @@ namespace Apache.IoTDB
             get => TimeoutInMs / 1000;
             set => TimeoutInMs = value * 1000;
         }
+
+        /// <summary>
+        /// Attempts to take a client without ever blocking. Returns false when no client is idle.
+        /// Use this for probes and diagnostics, which must not queue behind ordinary work.
+        /// </summary>
+        public bool TryTake(out Client client) => ClientQueue.TryDequeue(out client);
 
         public Client Take()
         {

--- a/src/Apache.IoTDB/SessionPool.cs
+++ b/src/Apache.IoTDB/SessionPool.cs
@@ -471,11 +471,61 @@ namespace Apache.IoTDB
         /// <remarks>
         /// This reflects the lifecycle of the pool object only - it is NOT a server-connectivity probe.
         /// The client performs no heartbeat, so a server going down does not flip this back to false;
-        /// it stays true until <see cref="Close"/> is called. To reason about connectivity, use
-        /// <see cref="AvailableClients"/>, <see cref="UnrealizedCapacity"/> and <see cref="FailedReconnections"/>,
-        /// or simply let an operation throw <see cref="SessionPoolDepletedException"/>.
+        /// it stays true until <see cref="Close"/> is called. Use <see cref="CheckHealthAsync"/> when you
+        /// need to know whether the server is actually reachable, or read <see cref="AvailableClients"/>,
+        /// <see cref="UnrealizedCapacity"/> and <see cref="FailedReconnections"/> for pool state.
         /// </remarks>
         public bool IsOpen() => !_isClose;
+
+        /// <summary>
+        /// Probes server connectivity by issuing one lightweight request on an idle pooled connection,
+        /// and returns a snapshot of the result. This is the connectivity check that <see cref="IsOpen"/>
+        /// is often mistaken for.
+        /// </summary>
+        /// <remarks>
+        /// The probe never blocks waiting for a connection: if every client is busy, the call returns
+        /// <see cref="SessionPoolHealthStatus.Degraded"/> immediately rather than queueing behind ordinary
+        /// work. The borrowed connection is always returned to the pool, and a failed probe does not close
+        /// it - the regular reconnect-on-use path still applies to the next operation.
+        /// Pass a cancellation token if you want to bound how long the probe may take.
+        /// </remarks>
+        public async Task<SessionPoolHealth> CheckHealthAsync(CancellationToken cancellationToken = default)
+        {
+            if (_isClose || _clients == null)
+            {
+                return new SessionPoolHealth(SessionPoolHealthStatus.NotOpen, 0, TotalPoolSize, FailedReconnections,
+                    "The pool has not been opened yet, or it has already been closed.");
+            }
+
+            if (!_clients.TryTake(out var client))
+            {
+                return new SessionPoolHealth(SessionPoolHealthStatus.Degraded, 0, TotalPoolSize, FailedReconnections,
+                    "No idle connection was available to probe. The pool is either saturated by concurrent work or has lost its connections.");
+            }
+
+            SessionPoolHealthStatus status;
+            string message;
+            Exception error = null;
+            try
+            {
+                await client.ServiceClient.getTimeZoneAsync(client.SessionId, cancellationToken);
+                status = SessionPoolHealthStatus.Healthy;
+                message = "The server answered the probe.";
+            }
+            catch (Exception e)
+            {
+                status = SessionPoolHealthStatus.Unhealthy;
+                message = $"The server did not answer the probe: {e.Message}";
+                error = e;
+                _logger?.LogWarning(e, "Health probe failed for session pool");
+            }
+            finally
+            {
+                _clients.Add(client);
+            }
+
+            return new SessionPoolHealth(status, AvailableClients, TotalPoolSize, FailedReconnections, message, error);
+        }
 
         public async Task Close()
         {

--- a/src/Apache.IoTDB/SessionPoolHealth.cs
+++ b/src/Apache.IoTDB/SessionPoolHealth.cs
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+
+namespace Apache.IoTDB
+{
+    /// <summary>
+    /// Outcome of a <see cref="SessionPool.CheckHealthAsync"/> probe.
+    /// </summary>
+    public enum SessionPoolHealthStatus
+    {
+        /// <summary>
+        /// The pool has not been opened yet, or it has already been closed.
+        /// </summary>
+        NotOpen,
+
+        /// <summary>
+        /// The server answered the probe on a pooled connection.
+        /// </summary>
+        Healthy,
+
+        /// <summary>
+        /// The pool is open but could not be probed, because no connection was idle at that moment.
+        /// This says nothing about the server: the pool may simply be saturated by concurrent work.
+        /// </summary>
+        Degraded,
+
+        /// <summary>
+        /// A connection was available but the server did not answer the probe.
+        /// </summary>
+        Unhealthy
+    }
+
+    /// <summary>
+    /// A point-in-time snapshot of pool connectivity, returned by <see cref="SessionPool.CheckHealthAsync"/>.
+    /// Unlike <see cref="SessionPool.IsOpen"/> - which only reports whether the caller has opened the pool -
+    /// this reflects whether the server actually answered just now.
+    /// </summary>
+    public class SessionPoolHealth
+    {
+        /// <summary>
+        /// The probe outcome.
+        /// </summary>
+        public SessionPoolHealthStatus Status { get; }
+
+        /// <summary>
+        /// True only when <see cref="Status"/> is <see cref="SessionPoolHealthStatus.Healthy"/>.
+        /// </summary>
+        public bool IsHealthy => Status == SessionPoolHealthStatus.Healthy;
+
+        /// <summary>
+        /// Idle clients in the pool at the time the snapshot was taken.
+        /// </summary>
+        public int AvailableClients { get; }
+
+        /// <summary>
+        /// Configured maximum capacity of the pool.
+        /// </summary>
+        public int TotalPoolSize { get; }
+
+        /// <summary>
+        /// Cumulative tally of reconnection failures since the pool was opened.
+        /// </summary>
+        public int FailedReconnections { get; }
+
+        /// <summary>
+        /// Human-readable explanation of <see cref="Status"/>.
+        /// </summary>
+        public string Message { get; }
+
+        /// <summary>
+        /// The exception that caused an <see cref="SessionPoolHealthStatus.Unhealthy"/> result, if any.
+        /// </summary>
+        public Exception Error { get; }
+
+        public SessionPoolHealth(SessionPoolHealthStatus status, int availableClients, int totalPoolSize,
+            int failedReconnections, string message, Exception error = null)
+        {
+            Status = status;
+            AvailableClients = availableClients;
+            TotalPoolSize = totalPoolSize;
+            FailedReconnections = failedReconnections;
+            Message = message;
+            Error = error;
+        }
+
+        public override string ToString()
+            => $"{Status}: {Message} (available {AvailableClients}/{TotalPoolSize}, failed reconnections {FailedReconnections})";
+    }
+}

--- a/src/Apache.IoTDB/TableSessionPool.cs
+++ b/src/Apache.IoTDB/TableSessionPool.cs
@@ -70,6 +70,15 @@ public partial class TableSessionPool
         sessionPool.OpenDebugMode(configure);
     }
 
+    /// <summary>
+    /// Probes server connectivity on an idle pooled connection. See
+    /// <see cref="SessionPool.CheckHealthAsync"/> for the semantics.
+    /// </summary>
+    public async Task<SessionPoolHealth> CheckHealthAsync(CancellationToken cancellationToken = default)
+    {
+        return await sessionPool.CheckHealthAsync(cancellationToken);
+    }
+
     public async Task Close()
     {
         await sessionPool.Close();

--- a/tests/Apache.IoTDB.Tests/SessionPoolHealthTests.cs
+++ b/tests/Apache.IoTDB.Tests/SessionPoolHealthTests.cs
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Apache.IoTDB.Tests
+{
+    [TestFixture]
+    public class SessionPoolHealthTests
+    {
+        private static Client NewStubClient() => new Client(null, 1L, 1L, null, null);
+
+        private static SessionPool NewUnopenedPool()
+            => new SessionPool.Builder().SetHost("127.0.0.1").SetPort(6667).Build();
+
+        [Test]
+        public async Task CheckHealthAsync_PoolNeverOpened_ReportsNotOpen()
+        {
+            var health = await NewUnopenedPool().CheckHealthAsync();
+
+            Assert.That(health.Status, Is.EqualTo(SessionPoolHealthStatus.NotOpen));
+            Assert.That(health.IsHealthy, Is.False);
+            Assert.That(health.Error, Is.Null);
+        }
+
+        [Test]
+        public async Task CheckHealthAsync_PoolNeverOpened_ReturnsPromptlyWithoutTouchingTheNetwork()
+        {
+            // The probe must not attempt to connect, and must never block on the empty queue.
+            var stopwatch = Stopwatch.StartNew();
+            var health = await NewUnopenedPool().CheckHealthAsync();
+            stopwatch.Stop();
+
+            Assert.That(health.Status, Is.EqualTo(SessionPoolHealthStatus.NotOpen));
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(2_000));
+        }
+
+        [Test]
+        public void IsOpen_StaysFalseUntilOpened()
+        {
+            // IsOpen is a lifecycle flag; CheckHealthAsync is the connectivity probe.
+            Assert.That(NewUnopenedPool().IsOpen(), Is.False);
+        }
+
+        [Test]
+        public void TryTake_EmptyQueue_ReturnsFalseImmediately()
+        {
+            var queue = new ConcurrentClientQueue { TimeoutInMs = 30_000 };
+            var stopwatch = Stopwatch.StartNew();
+
+            var taken = queue.TryTake(out var client);
+
+            stopwatch.Stop();
+            Assert.That(taken, Is.False);
+            Assert.That(client, Is.Null);
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.LessThan(1_000), "TryTake must never wait on the queue.");
+        }
+
+        [Test]
+        public void TryTake_ReturnsIdleClientWithoutRemovingOthers()
+        {
+            var queue = new ConcurrentClientQueue();
+            var first = NewStubClient();
+            var second = NewStubClient();
+            queue.Add(first);
+            queue.Add(second);
+
+            Assert.That(queue.TryTake(out var taken), Is.True);
+            Assert.That(taken, Is.SameAs(first));
+            Assert.That(queue.ClientQueue.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void SessionPoolHealth_ToStringIncludesStatusAndCounters()
+        {
+            var health = new SessionPoolHealth(SessionPoolHealthStatus.Unhealthy, 3, 8, 2, "probe failed", new Exception("boom"));
+
+            Assert.That(health.IsHealthy, Is.False);
+            Assert.That(health.ToString(), Does.Contain("Unhealthy"));
+            Assert.That(health.ToString(), Does.Contain("3/8"));
+            Assert.That(health.ToString(), Does.Contain("2"));
+        }
+
+        [Test]
+        public void SessionPoolHealth_HealthyStatusSetsIsHealthy()
+        {
+            var health = new SessionPoolHealth(SessionPoolHealthStatus.Healthy, 8, 8, 0, "ok");
+
+            Assert.That(health.IsHealthy, Is.True);
+            Assert.That(health.Error, Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
Addresses the third issue raised in #61 (the `IsOpen()` semantics discussion). Complements #62, which
fixes the two blocking defects; this PR adds the API that was deliberately left out of that one to keep it
focused on the bugs.

对应 #61 中提出的第三个议题（`IsOpen()` 语义讨论）。与 #62 互补：#62 修复两个导致阻塞的缺陷，本 PR 新增
当时为保持该 PR 聚焦于缺陷而刻意剥离的 API。

## Why / 背景

`IsOpen()` is `!_isClose`, and `_isClose` only flips on explicit `Open()` / `Close()`. The client keeps no
heartbeat, so a server going down never changes it. That is working as designed and matches the Java
client — but the name reads like a health check, and users write guards such as:

`IsOpen()` 即 `!_isClose`，只有显式 `Open()` / `Close()` 会改变它；客户端无心跳，服务端断开不会回写。
这是符合设计的（与 Java 客户端一致），但这个命名读起来像健康检查，于是用户会写出这样的守卫：

```csharp
// Never re-opens: IsOpen() stays true even while every connection is dead
if (_pool != null && _pool.IsOpen()) return;
```

Rather than change `IsOpen()` — which would be a silent behavioural break for anyone relying on the
lifecycle meaning — this PR adds the connectivity check it is mistaken for.

与其修改 `IsOpen()`（会对依赖其生命周期语义的使用方造成无声的行为破坏），本 PR 选择新增它被误认为具备的
连通性检查能力。

## What / 实现

`SessionPool.CheckHealthAsync(CancellationToken)` issues one lightweight request on an idle pooled
connection and returns a `SessionPoolHealth` snapshot (`Status`, `AvailableClients`, `TotalPoolSize`,
`FailedReconnections`, `Message`, `Error`).

`SessionPool.CheckHealthAsync(CancellationToken)` 在空闲连接上发送一次轻量请求，返回 `SessionPoolHealth`
快照（状态、可用连接数、池容量、重连失败次数、说明、底层异常）。

```csharp
var health = await sessionPool.CheckHealthAsync();
if (!health.IsHealthy)
{
    logger.LogWarning("{Health}", health);   // "Unhealthy: The server did not answer the probe: ..."
}
```

| `SessionPoolHealthStatus` | Meaning / 含义                                                                        |
| ------------------------- | ------------------------------------------------------------------------------------- |
| `NotOpen`                 | Pool not opened, or already closed. No network call is attempted. 池未打开或已关闭，不发起网络调用 |
| `Healthy`                 | The server answered the probe. 服务端已响应探测                                        |
| `Degraded`                | Open, but no idle connection to probe with. 已打开但无空闲连接可探测                     |
| `Unhealthy`               | A connection was available but the server did not answer. 有可用连接但服务端未响应        |

Design decisions worth reviewing / 需要评审关注的设计决策:

- **The probe never blocks.** `ConcurrentClientQueue.TryTake` is added for this. A health endpoint must not
  queue behind application load, so when every client is busy the probe returns `Degraded` at once rather
  than waiting. This also keeps the probe independent of the pool wait timeout fixed in #62.
  **探针永不阻塞**：为此新增 `ConcurrentClientQueue.TryTake`。健康检查端点不应排在业务负载之后，所以所有
  连接繁忙时立即返回 `Degraded`。这也使探针不依赖 #62 中修复的池等待超时。
- **`Degraded` is deliberately not a server verdict.** It only means nothing was idle at that instant.
  Treating saturation as an outage would make the check useless under load.
  **`Degraded` 刻意不表示服务端故障**，只表示当时没有空闲连接。把饱和当作故障会让该检查在高负载下失去意义。
- **The borrowed connection is always returned, and a failed probe does not close it.** The existing
  reconnect-on-use path still handles the dead connection on the next real operation, so the probe has no
  side effects on pool state.
  **借出的连接总会归还，探测失败也不关闭它**：失效连接仍由既有的按需重连路径在下次真实操作时处理，探针
  对池状态无副作用。
- **No implicit timeout.** Callers bound the probe with a `CancellationToken` if they want to; adding a
  hidden default felt worse than making it explicit. Happy to add one if reviewers disagree.
  **不设隐式超时**：调用方可用 `CancellationToken` 自行限时。相比隐藏的默认值，显式更好。若评审有不同
  意见，可以加上。

`TableSessionPool` forwards the method with identical semantics.
`TableSessionPool` 以相同语义转发该方法。

## Relationship to #62 / 与 #62 的关系

#62 is now merged (`178ebb0`), and this branch has been rebased onto it. Because #62 was squash-merged, the
three commits this branch previously carried no longer matched upstream and GitHub reported a conflict; I
rebased with `--onto upstream/main` so only the health-check commit remains. **This PR is now a single
commit against current `main` with no conflicts.**

#62 已合并（`178ebb0`），本分支已 rebase 到其之上。由于 #62 采用 squash 合并，本分支原先携带的三个提交
与上游不再匹配，GitHub 因此报告冲突；我使用 `--onto upstream/main` 进行 rebase，只保留健康检查这一个提交。
**本 PR 现在是基于当前 `main` 的单个提交，无冲突。**

The overlaps with #62 were resolved during the earlier rebase and carried through:
与 #62 的重叠已在此前的 rebase 中解决并延续至今：

- `ConcurrentClientQueue` — `TryTake` sits alongside #62's `TimeoutInMs` and the obsolete `Timeout` shim;
  the tests set `TimeoutInMs`.
  `TryTake` 与 #62 的 `TimeoutInMs` 及过时的 `Timeout` 兼容属性并存；测试使用 `TimeoutInMs`。
- `IsOpen()` XML docs — points at `CheckHealthAsync` for connectivity and at the pool-state properties
  (including #62's `UnrealizedCapacity`) for diagnostics.
  同时指向 `CheckHealthAsync`（连通性）与池状态属性（诊断，含 #62 的 `UnrealizedCapacity`）。
- `docs/SessionPool_Exception_Handling.md` — the `CheckHealthAsync` vs `IsOpen` section sits next to #62's
  "Pool Wait Timeout" section, and notes that the probe is unaffected by that timeout.
  `CheckHealthAsync` 与 `IsOpen` 的对比章节与 #62 的 "Pool Wait Timeout" 章节并列，并说明探针不受该超时影响。

## Tests / 测试

`SessionPoolHealthTests` covers the `NotOpen` path (asserting no network call is attempted and the call
returns promptly), the non-blocking `TryTake` semantics, and the `SessionPoolHealth` snapshot itself.

`SessionPoolHealthTests` 覆盖 `NotOpen` 路径（断言不发起网络调用且立即返回）、`TryTake` 的非阻塞语义，
以及 `SessionPoolHealth` 快照本身。

`dotnet test tests/Apache.IoTDB.Tests` — 29 passed, 0 failed. `dotnet build Apache.IoTDB.sln` — 0 errors.
`dotnet format --verify-no-changes` — clean.

The `Healthy` / `Unhealthy` transitions need a live server and are left to the e2e suite rather than
simulated with a mock transport.
`Healthy` / `Unhealthy` 的状态转换需要真实服务端，交由 e2e 套件覆盖，未用 mock transport 模拟。

Note: the unit tests were executed locally against `net8.0` because no .NET 5 arm64 runtime is available on
this machine; the committed `TargetFramework` is unchanged at `net5.0`.
说明：本机没有 .NET 5 的 arm64 运行时，单元测试在本地以 `net8.0` 执行；提交的 `TargetFramework` 仍为 `net5.0`。

## Docs / 文档

- `docs/SessionPool_Exception_Handling.md` — new section contrasting `CheckHealthAsync` with `IsOpen`, the
  status table, behaviour notes, and the existing health-check example rewritten to delegate to the
  built-in probe.
  `docs/SessionPool_Exception_Handling.md` —— 新增对比 `CheckHealthAsync` 与 `IsOpen` 的章节、状态表、
  行为说明，并将原有的健康检查示例改写为委托给内置探针。
- `docs/API.md` — added the `CheckHealthAsync` row and clarified `IsOpen`.
  `docs/API.md` —— 新增 `CheckHealthAsync` 一行并澄清 `IsOpen`。


